### PR TITLE
Added functionality for custom sender name and req_feat

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -55,7 +55,7 @@ function parseResponseBody(strRespBody, deferred) {
   }
 }
 
-function send(reqSender, httpOpts, params) {    
+function send(reqSender, httpOpts, params) {
   var deferred = Q.defer();
   var dataToSend = queryStringify(params);
   var req;
@@ -69,7 +69,7 @@ function send(reqSender, httpOpts, params) {
   if (0 < dataToSend.length) {
     if ('POST' === httpOpts.method) {
       // Content-Type: application/x-www-form-urlencoded is required not to receive 'ERR: 001, Authentication failed'
-      httpOpts.headers['Content-Length'] = dataToSend.length; 
+      httpOpts.headers['Content-Length'] = dataToSend.length;
       httpOpts.headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=utf-8';
     } else {
       httpOpts.path += '?' + dataToSend;
@@ -124,7 +124,7 @@ module.exports = function (apiId, user, password, options) {
 
       reqSender.forEach(function (secOpt) {
         if (options.secured[secOpt]) {
-          httpOpts[secOpt] = options.secured[secOpt]; 
+          httpOpts[secOpt] = options.secured[secOpt];
         }
       });
     }
@@ -135,16 +135,18 @@ module.exports = function (apiId, user, password, options) {
   }
 
   return {
-    sendMessage: 
-      function (to, text, options) {
+    sendMessage:
+      function (to, text, from, feat, options) {
         var httpOpts;
         var params;
-        
+
         httpOpts = _extend({ path: '/http/sendmsg' }, httpReqOpts);
         params = _extend({
           to: to,
-          text: text
-        }, requiredParams);        
+          text: text,
+          from: from,
+          req_feat: feat
+        }, requiredParams);
 
         if (options) {
           params = _extend(params, options);
@@ -153,42 +155,42 @@ module.exports = function (apiId, user, password, options) {
         return send(reqSender, httpOpts, params);
       },
 
-    queryMessage: 
+    queryMessage:
       function (apiMsgId) {
         var httpOpts;
         var params;
-        
+
         httpOpts = _extend({ path: '/http/querymsg' }, httpReqOpts);
         params = _extend({
           apimsgid: apiMsgId
-        }, requiredParams); 
+        }, requiredParams);
 
         return send(reqSender, httpOpts, params);
       },
 
-    deleteMessage: 
+    deleteMessage:
       function (apiMsgId) {
         var httpOpts;
         var params;
-        
+
         httpOpts = _extend({ path: '/http/delmsg' }, httpReqOpts);
         params = _extend({
           apimsgid: apiMsgId
-        }, requiredParams); 
-        
+        }, requiredParams);
+
         return send(reqSender, httpOpts, params);
       },
 
-    getBalance: 
+    getBalance:
       function () {
         var httpOpts;
-        
+
         httpOpts = _extend({ path: '/http/getbalance' }, httpReqOpts);
-        
+
         return send(reqSender, httpOpts, requiredParams);
       },
-    
-    routeCoverage: 
+
+    routeCoverage:
       function (msisdn) {
         var httpOpts;
         var params;
@@ -196,13 +198,13 @@ module.exports = function (apiId, user, password, options) {
         httpOpts = _extend({ path: '/utils/routeCoverage' }, httpReqOpts);
         params = _extend({
           msisdn: msisdn
-        }, requiredParams); 
-      
+        }, requiredParams);
+
         return send(reqSender, httpOpts, params);
       },
 
 
-    getMessageChargeByCliId: 
+    getMessageChargeByCliId:
       function (climsgid) {
         var httpOpts;
         var params;
@@ -210,12 +212,12 @@ module.exports = function (apiId, user, password, options) {
         httpOpts = _extend({ path: '/http/getmsgcharge' }, httpReqOpts);
         params = _extend({
           climsgid: climsgid
-        }, requiredParams); 
-      
+        }, requiredParams);
+
         return send(reqSender, httpOpts, params);
       },
 
-    getMessageChargeByApiId: 
+    getMessageChargeByApiId:
       function (apimsgid) {
         var httpOpts;
         var params;
@@ -223,12 +225,12 @@ module.exports = function (apiId, user, password, options) {
         httpOpts = _extend({ path: '/http/getmsgcharge' }, httpReqOpts);
         params = _extend({
           apimsgid: apimsgid
-        }, requiredParams); 
-      
+        }, requiredParams);
+
         return send(reqSender, httpOpts, params);
       },
 
-    spendVoucher: 
+    spendVoucher:
       function (token) {
         var httpOpts;
         var params;
@@ -236,12 +238,12 @@ module.exports = function (apiId, user, password, options) {
         httpOpts = _extend({ path: '/http/token_pay' }, httpReqOpts);
         params = _extend({
           token: token
-        }, requiredParams); 
-      
+        }, requiredParams);
+
         return send(reqSender, httpOpts, params);
       },
 
-    startBatch: 
+    startBatch:
       function (template, options) {
         var httpOpts;
         var params;
@@ -249,8 +251,8 @@ module.exports = function (apiId, user, password, options) {
         httpOpts = _extend({ path: '/http_batch/startbatch' }, httpReqOpts);
         params = _extend({
           template: template
-        }, requiredParams); 
-      
+        }, requiredParams);
+
         if (options) {
           params = _extend(params, options);
         }
@@ -267,8 +269,8 @@ module.exports = function (apiId, user, password, options) {
         params = _extend({
           batch_id: batchId,
           to: to
-        }, requiredParams); 
-      
+        }, requiredParams);
+
         if (fields) {
           params = _extend(params, fields);
         }
@@ -285,8 +287,8 @@ module.exports = function (apiId, user, password, options) {
         params = _extend({
           batch_id: batchId,
           to: to
-        }, requiredParams); 
-        
+        }, requiredParams);
+
         return send(reqSender, httpOpts, params);
       },
 
@@ -298,8 +300,8 @@ module.exports = function (apiId, user, password, options) {
         httpOpts = _extend({ path: '/http_batch/endbatch' }, httpReqOpts);
         params = _extend({
           batch_id: batchId
-        }, requiredParams); 
-      
+        }, requiredParams);
+
         return send(reqSender, httpOpts, params);
       }
   };


### PR DESCRIPTION
req_feat is poorly documented parameter search for it inside this document to understand the functionality.
In general you need to specify it to make sure  that sender ID is set.
http://www.clickatell.com/downloads/Clickatell_Sender_ID_User_Guide.pdf

Example:
cktHttp.sendMessage('send to number', 'Message to send', 'Your custom ID', 48)
